### PR TITLE
feat: Phase 2 - 정적 데이터로 상점 목록 표시

### DIFF
--- a/lib/data/dummy_shops.dart
+++ b/lib/data/dummy_shops.dart
@@ -1,0 +1,269 @@
+import '../models/shop.dart';
+
+class DummyShops {
+  static final List<Shop> shops = [
+    // 오프라인 매장들
+    Shop(
+      id: '1',
+      name: '발레리나 하우스',
+      shopType: ShopType.offline,
+      description: '강남구 최대 규모의 발레 용품 전문점입니다. 다양한 브랜드와 사이즈를 보유하고 있습니다.',
+      brands: ['Repetto', 'Bloch', 'Capezio', 'Grishko', 'Wear Moi'],
+      rating: 4.8,
+      reviewCount: 234,
+      imageUrl: 'https://picsum.photos/400/300?random=1',
+      address: '서울특별시 강남구 신사동 123-45',
+      phone: '02-1234-5678',
+      latitude: 37.5172,
+      longitude: 127.0473,
+      businessHours: '평일 10:00-20:00, 주말 11:00-19:00',
+      parkingAvailable: true,
+      fittingAvailable: true,
+      categories: ['토슈즈', '레오타드', '타이즈', '워머', '가방'],
+      isVerified: true,
+    ),
+    
+    Shop(
+      id: '2',
+      name: '댄스마트 대학로점',
+      shopType: ShopType.offline,
+      description: '무용 전공생들이 가장 많이 찾는 대학로 발레 용품점',
+      brands: ['Sansha', 'So Danca', 'Body Wrappers', 'Mirella'],
+      rating: 4.6,
+      reviewCount: 189,
+      imageUrl: 'https://picsum.photos/400/300?random=2',
+      address: '서울특별시 종로구 대학로 87',
+      phone: '02-9876-5432',
+      latitude: 37.5827,
+      longitude: 127.0037,
+      businessHours: '매일 09:00-21:00',
+      parkingAvailable: false,
+      fittingAvailable: true,
+      categories: ['토슈즈', '레오타드', '연습복', '액세서리'],
+      isVerified: true,
+    ),
+    
+    Shop(
+      id: '3',
+      name: '핑크튜튜',
+      shopType: ShopType.offline,
+      description: '어린이 발레 용품 전문점. 키즈 사이즈 다양하게 구비',
+      brands: ['Capezio Kids', 'Dansco', 'Bloch Kids'],
+      rating: 4.9,
+      reviewCount: 156,
+      imageUrl: 'https://picsum.photos/400/300?random=3',
+      address: '서울특별시 송파구 잠실동 22-3',
+      phone: '02-424-8888',
+      latitude: 37.5145,
+      longitude: 127.1003,
+      businessHours: '화-일 10:00-19:00 (월요일 휴무)',
+      parkingAvailable: true,
+      fittingAvailable: true,
+      categories: ['키즈 레오타드', '키즈 토슈즈', '튜튜 드레스'],
+      isVerified: false,
+    ),
+    
+    // 온라인 쇼핑몰들
+    Shop(
+      id: '4',
+      name: '발레몰',
+      shopType: ShopType.online,
+      description: '국내 최대 발레 용품 온라인 쇼핑몰. 24시간 주문 가능',
+      brands: ['Repetto', 'Gaynor Minden', 'Russian Pointe', 'Freed', 'Grishko'],
+      rating: 4.5,
+      reviewCount: 892,
+      imageUrl: 'https://picsum.photos/400/300?random=4',
+      websiteUrl: 'https://www.balletmall.co.kr',
+      phone: '1588-1234',
+      shippingFee: 3000,
+      freeShippingMin: 50000,
+      deliveryInfo: '평균 2-3일 소요, 당일배송 가능(서울/경기)',
+      categories: ['토슈즈', '레오타드', '타이즈', '워머', '가방', '액세서리'],
+      isVerified: true,
+    ),
+    
+    Shop(
+      id: '5',
+      name: '댄스코리아',
+      shopType: ShopType.online,
+      description: '발레, 현대무용, 재즈댄스 용품 종합 쇼핑몰',
+      brands: ['Wear Moi', 'Intermezzo', 'Temps Danse', 'Ballet Rosa'],
+      rating: 4.3,
+      reviewCount: 567,
+      imageUrl: 'https://picsum.photos/400/300?random=5',
+      websiteUrl: 'https://www.dancekorea.com',
+      phone: '1577-8282',
+      shippingFee: 2500,
+      freeShippingMin: 30000,
+      deliveryInfo: '평균 3-5일 소요',
+      categories: ['레오타드', '타이즈', '연습복', '무용화'],
+      isVerified: true,
+    ),
+    
+    Shop(
+      id: '6',
+      name: '발레리노샵',
+      shopType: ShopType.online,
+      description: '수입 브랜드 전문 온라인 편집샵',
+      brands: ['Yumiko', 'Eleve', 'Lucky Leo', 'Cloud & Victory'],
+      rating: 4.7,
+      reviewCount: 234,
+      imageUrl: 'https://picsum.photos/400/300?random=6',
+      websiteUrl: 'https://www.ballerinoshop.kr',
+      phone: '02-3333-4444',
+      shippingFee: 5000,
+      freeShippingMin: 100000,
+      deliveryInfo: '평균 5-7일 소요 (해외직구 상품 2-3주)',
+      categories: ['수입 레오타드', '디자이너 브랜드', '커스텀 의상'],
+      isVerified: false,
+    ),
+    
+    // 하이브리드 (온/오프라인)
+    Shop(
+      id: '7',
+      name: '그리쉬코 코리아',
+      shopType: ShopType.hybrid,
+      description: 'Grishko 공식 수입사. 온라인몰과 쇼룸 운영',
+      brands: ['Grishko', 'Grishko Pro', 'Nikolay'],
+      rating: 4.9,
+      reviewCount: 445,
+      imageUrl: 'https://picsum.photos/400/300?random=7',
+      address: '서울특별시 강남구 청담동 45-12',
+      phone: '02-543-7890',
+      latitude: 37.5197,
+      longitude: 127.0474,
+      businessHours: '평일 11:00-19:00 (예약제)',
+      parkingAvailable: true,
+      fittingAvailable: true,
+      websiteUrl: 'https://www.grishko.co.kr',
+      shippingFee: 0,
+      freeShippingMin: 0,
+      deliveryInfo: '전 상품 무료배송',
+      categories: ['토슈즈', '포인트슈즈', '레오타드', '전문가용품'],
+      isVerified: true,
+    ),
+    
+    Shop(
+      id: '8',
+      name: '블로흐 부산',
+      shopType: ShopType.offline,
+      description: '부산 지역 최대 발레 용품점. Bloch 공식 딜러',
+      brands: ['Bloch', 'Bloch Pro', 'Mirella', 'Leo'],
+      rating: 4.5,
+      reviewCount: 178,
+      imageUrl: 'https://picsum.photos/400/300?random=8',
+      address: '부산광역시 해운대구 중동 1234',
+      phone: '051-747-9999',
+      latitude: 35.1628,
+      longitude: 129.1639,
+      businessHours: '매일 10:00-20:00',
+      parkingAvailable: true,
+      fittingAvailable: true,
+      categories: ['토슈즈', '레오타드', '타이즈', '재즈슈즈'],
+      isVerified: true,
+    ),
+    
+    Shop(
+      id: '9',
+      name: '튜튜앤레오',
+      shopType: ShopType.online,
+      description: '합리적인 가격의 입문자용 발레 용품 전문',
+      brands: ['Body Wrappers', 'Danznmotion', 'Motionwear'],
+      rating: 4.2,
+      reviewCount: 334,
+      imageUrl: 'https://picsum.photos/400/300?random=9',
+      websiteUrl: 'https://www.tutuleo.com',
+      phone: '070-8888-1234',
+      shippingFee: 2500,
+      freeShippingMin: 25000,
+      deliveryInfo: '평균 2-3일 소요',
+      categories: ['입문자용품', '레오타드', '타이즈', '슈즈'],
+      isVerified: false,
+    ),
+    
+    Shop(
+      id: '10',
+      name: '아라베스크',
+      shopType: ShopType.offline,
+      description: '20년 전통의 발레 용품 전문점',
+      brands: ['Capezio', 'Sansha', 'Freed', 'Suffolk'],
+      rating: 4.6,
+      reviewCount: 423,
+      imageUrl: 'https://picsum.photos/400/300?random=10',
+      address: '서울특별시 서초구 서초동 1650-3',
+      phone: '02-3473-1234',
+      latitude: 37.4967,
+      longitude: 127.0276,
+      businessHours: '평일 10:00-19:00, 토요일 10:00-17:00 (일요일 휴무)',
+      parkingAvailable: false,
+      fittingAvailable: true,
+      categories: ['토슈즈', '레오타드', '전문가용품', '무대의상'],
+      isVerified: true,
+    ),
+    
+    Shop(
+      id: '11',
+      name: '발레스타',
+      shopType: ShopType.hybrid,
+      description: '온라인 주문 후 매장 픽업 가능. 맞춤 의상 제작',
+      brands: ['Custom Made', 'Wear Moi', 'Intermezzo'],
+      rating: 4.8,
+      reviewCount: 267,
+      imageUrl: 'https://picsum.photos/400/300?random=11',
+      address: '서울특별시 마포구 상수동 72-1',
+      phone: '02-322-5678',
+      latitude: 37.5478,
+      longitude: 126.9227,
+      businessHours: '화-토 11:00-20:00',
+      parkingAvailable: false,
+      fittingAvailable: true,
+      websiteUrl: 'https://www.balletstar.kr',
+      shippingFee: 3000,
+      freeShippingMin: 40000,
+      deliveryInfo: '맞춤제작 2-3주 소요',
+      categories: ['맞춤의상', '무대의상', '레오타드', '튜튜'],
+      isVerified: false,
+    ),
+    
+    Shop(
+      id: '12',
+      name: '리틀발레리나',
+      shopType: ShopType.online,
+      description: '유아 및 어린이 발레 용품 전문 온라인몰',
+      brands: ['Capezio Kids', 'Bloch Kids', 'Dansco Kids'],
+      rating: 4.9,
+      reviewCount: 445,
+      imageUrl: 'https://picsum.photos/400/300?random=12',
+      websiteUrl: 'https://www.littleballerina.co.kr',
+      phone: '1599-8282',
+      shippingFee: 2500,
+      freeShippingMin: 20000,
+      deliveryInfo: '평균 1-2일 소요',
+      categories: ['키즈레오타드', '키즈슈즈', '키즈타이즈', '헤어액세서리'],
+      isVerified: true,
+    ),
+  ];
+  
+  // 상점 유형별 필터링
+  static List<Shop> get offlineShops => 
+    shops.where((shop) => shop.isOffline).toList();
+  
+  static List<Shop> get onlineShops => 
+    shops.where((shop) => shop.isOnline).toList();
+  
+  // ID로 상점 찾기
+  static Shop? getShopById(String id) {
+    try {
+      return shops.firstWhere((shop) => shop.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+  
+  // 브랜드로 상점 검색
+  static List<Shop> searchByBrand(String brand) {
+    return shops.where((shop) => 
+      shop.brands.any((b) => b.toLowerCase().contains(brand.toLowerCase()))
+    ).toList();
+  }
+}

--- a/lib/models/shop.dart
+++ b/lib/models/shop.dart
@@ -1,0 +1,81 @@
+enum ShopType {
+  offline('오프라인'),
+  online('온라인'),
+  hybrid('온/오프라인');
+  
+  final String displayName;
+  const ShopType(this.displayName);
+}
+
+class Shop {
+  final String id;
+  final String name;
+  final ShopType shopType;
+  final String description;
+  final List<String> brands;
+  final double rating;
+  final int reviewCount;
+  final String imageUrl;
+  
+  // 오프라인 상점 정보
+  final String? address;
+  final String? phone;
+  final double? latitude;
+  final double? longitude;
+  final String? businessHours;
+  final bool? parkingAvailable;
+  final bool? fittingAvailable;
+  
+  // 온라인 상점 정보
+  final String? websiteUrl;
+  final int? shippingFee;
+  final int? freeShippingMin;
+  final String? deliveryInfo;
+  
+  // 공통 추가 정보
+  final List<String> categories;
+  final bool isVerified;
+  final DateTime createdAt;
+
+  Shop({
+    required this.id,
+    required this.name,
+    required this.shopType,
+    required this.description,
+    required this.brands,
+    required this.rating,
+    required this.reviewCount,
+    required this.imageUrl,
+    this.address,
+    this.phone,
+    this.latitude,
+    this.longitude,
+    this.businessHours,
+    this.parkingAvailable,
+    this.fittingAvailable,
+    this.websiteUrl,
+    this.shippingFee,
+    this.freeShippingMin,
+    this.deliveryInfo,
+    required this.categories,
+    this.isVerified = false,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+  
+  // 오프라인 상점인지 확인
+  bool get isOffline => shopType == ShopType.offline || shopType == ShopType.hybrid;
+  
+  // 온라인 상점인지 확인
+  bool get isOnline => shopType == ShopType.online || shopType == ShopType.hybrid;
+  
+  // 무료배송 여부
+  bool get hasFreeShipping => 
+    isOnline && freeShippingMin != null && freeShippingMin! > 0;
+  
+  // 주요 브랜드 (최대 3개)
+  List<String> get mainBrands => 
+    brands.take(3).toList();
+  
+  // 평점 텍스트
+  String get ratingText => rating.toStringAsFixed(1);
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,8 +1,33 @@
 import 'package:flutter/material.dart';
 import '../theme/app_colors.dart';
+import '../data/dummy_shops.dart';
+import '../models/shop.dart';
+import '../widgets/shop_card.dart';
+import 'shop_detail_screen.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  ShopType? selectedFilter;
+  List<Shop> filteredShops = DummyShops.shops;
+
+  void _filterShops(ShopType? type) {
+    setState(() {
+      selectedFilter = type;
+      if (type == null) {
+        filteredShops = DummyShops.shops;
+      } else {
+        filteredShops = DummyShops.shops
+            .where((shop) => shop.shopType == type)
+            .toList();
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -10,31 +35,149 @@ class HomeScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('발레 용품점 찾기'),
         automaticallyImplyLeading: false,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.filter_list),
+            onPressed: () {
+              _showFilterBottomSheet(context);
+            },
+          ),
+        ],
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.store,
-              size: 80,
-              color: AppColors.primaryAccent.withOpacity(0.5),
+      body: Column(
+        children: [
+          // 필터 칩들
+          Container(
+            height: 50,
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              children: [
+                FilterChip(
+                  label: const Text('전체'),
+                  selected: selectedFilter == null,
+                  onSelected: (_) => _filterShops(null),
+                  selectedColor: AppColors.primaryPink,
+                ),
+                const SizedBox(width: 8),
+                FilterChip(
+                  label: const Text('오프라인'),
+                  selected: selectedFilter == ShopType.offline,
+                  onSelected: (_) => _filterShops(ShopType.offline),
+                  selectedColor: AppColors.offlineShop.withAlpha(102),
+                ),
+                const SizedBox(width: 8),
+                FilterChip(
+                  label: const Text('온라인'),
+                  selected: selectedFilter == ShopType.online,
+                  onSelected: (_) => _filterShops(ShopType.online),
+                  selectedColor: AppColors.onlineShop.withAlpha(102),
+                ),
+                const SizedBox(width: 8),
+                FilterChip(
+                  label: const Text('온/오프라인'),
+                  selected: selectedFilter == ShopType.hybrid,
+                  onSelected: (_) => _filterShops(ShopType.hybrid),
+                  selectedColor: AppColors.secondaryPurple,
+                ),
+              ],
             ),
-            const SizedBox(height: 16),
-            Text(
-              '홈 화면',
-              style: Theme.of(context).textTheme.headlineMedium,
+          ),
+          
+          // 상점 개수
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            alignment: Alignment.centerLeft,
+            child: Text(
+              '총 ${filteredShops.length}개 상점',
+              style: Theme.of(context).textTheme.bodySmall,
             ),
-            const SizedBox(height: 8),
-            Text(
-              '상점 목록이 여기에 표시됩니다',
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: AppColors.gray,
+          ),
+          
+          // 상점 리스트
+          Expanded(
+            child: ListView.builder(
+              itemCount: filteredShops.length,
+              itemBuilder: (context, index) {
+                final shop = filteredShops[index];
+                return ShopCard(
+                  shop: shop,
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => ShopDetailScreen(shop: shop),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+  
+  void _showFilterBottomSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) {
+        return Container(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '상점 필터',
+                style: Theme.of(context).textTheme.headlineSmall,
               ),
-            ),
-          ],
-        ),
-      ),
+              const SizedBox(height: 20),
+              ListTile(
+                leading: const Icon(Icons.all_inclusive),
+                title: const Text('전체 보기'),
+                onTap: () {
+                  _filterShops(null);
+                  Navigator.pop(context);
+                },
+                selected: selectedFilter == null,
+              ),
+              ListTile(
+                leading: const Icon(Icons.store),
+                title: const Text('오프라인 매장'),
+                onTap: () {
+                  _filterShops(ShopType.offline);
+                  Navigator.pop(context);
+                },
+                selected: selectedFilter == ShopType.offline,
+              ),
+              ListTile(
+                leading: const Icon(Icons.shopping_cart),
+                title: const Text('온라인 쇼핑몰'),
+                onTap: () {
+                  _filterShops(ShopType.online);
+                  Navigator.pop(context);
+                },
+                selected: selectedFilter == ShopType.online,
+              ),
+              ListTile(
+                leading: const Icon(Icons.storefront),
+                title: const Text('온/오프라인 통합'),
+                onTap: () {
+                  _filterShops(ShopType.hybrid);
+                  Navigator.pop(context);
+                },
+                selected: selectedFilter == ShopType.hybrid,
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/shop_detail_screen.dart
+++ b/lib/screens/shop_detail_screen.dart
@@ -1,0 +1,421 @@
+import 'package:flutter/material.dart';
+import '../models/shop.dart';
+import '../theme/app_colors.dart';
+
+class ShopDetailScreen extends StatelessWidget {
+  final Shop shop;
+  
+  const ShopDetailScreen({
+    super.key,
+    required this.shop,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          // 앱바 & 이미지
+          SliverAppBar(
+            expandedHeight: 250,
+            pinned: true,
+            flexibleSpace: FlexibleSpaceBar(
+              title: Text(
+                shop.name,
+                style: const TextStyle(
+                  shadows: [
+                    Shadow(
+                      color: Colors.black54,
+                      blurRadius: 4,
+                    ),
+                  ],
+                ),
+              ),
+              background: Stack(
+                fit: StackFit.expand,
+                children: [
+                  Image.network(
+                    shop.imageUrl,
+                    fit: BoxFit.cover,
+                    errorBuilder: (context, error, stackTrace) {
+                      return Container(
+                        color: AppColors.lightGray,
+                        child: const Icon(
+                          Icons.store,
+                          size: 80,
+                          color: AppColors.gray,
+                        ),
+                      );
+                    },
+                  ),
+                  Container(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Colors.transparent,
+                          Colors.black.withAlpha(102),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.share),
+                onPressed: () {
+                  // TODO: 공유 기능
+                },
+              ),
+              IconButton(
+                icon: const Icon(Icons.favorite_border),
+                onPressed: () {
+                  // TODO: 즐겨찾기 기능
+                },
+              ),
+            ],
+          ),
+          
+          // 상세 정보
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 상점 유형 & 인증 배지
+                  Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                        decoration: BoxDecoration(
+                          color: _getShopTypeColor(shop.shopType),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              _getShopTypeIcon(shop.shopType),
+                              size: 16,
+                              color: AppColors.white,
+                            ),
+                            const SizedBox(width: 6),
+                            Text(
+                              shop.shopType.displayName,
+                              style: const TextStyle(
+                                color: AppColors.white,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      if (shop.isVerified)
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                          decoration: BoxDecoration(
+                            color: AppColors.success.withAlpha(26),
+                            borderRadius: BorderRadius.circular(20),
+                            border: Border.all(color: AppColors.success),
+                          ),
+                          child: const Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                Icons.verified,
+                                size: 16,
+                                color: AppColors.success,
+                              ),
+                              SizedBox(width: 4),
+                              Text(
+                                '인증매장',
+                                style: TextStyle(
+                                  color: AppColors.success,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  
+                  // 평점 & 리뷰
+                  Row(
+                    children: [
+                      ...List.generate(5, (index) {
+                        return Icon(
+                          index < shop.rating.floor() 
+                            ? Icons.star 
+                            : index < shop.rating 
+                              ? Icons.star_half 
+                              : Icons.star_border,
+                          color: AppColors.warning,
+                          size: 20,
+                        );
+                      }),
+                      const SizedBox(width: 8),
+                      Text(
+                        shop.ratingText,
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        '(리뷰 ${shop.reviewCount}개)',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  
+                  // 설명
+                  Text(
+                    '소개',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    shop.description,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 24),
+                  
+                  // 오프라인 매장 정보
+                  if (shop.isOffline) ...[
+                    _buildSectionTitle(context, Icons.location_on, '매장 정보'),
+                    const SizedBox(height: 12),
+                    _buildInfoCard(
+                      context,
+                      children: [
+                        if (shop.address != null)
+                          _buildInfoRow(Icons.home, '주소', shop.address!),
+                        if (shop.phone != null)
+                          _buildInfoRow(Icons.phone, '전화', shop.phone!),
+                        if (shop.businessHours != null)
+                          _buildInfoRow(Icons.access_time, '영업시간', shop.businessHours!),
+                        if (shop.parkingAvailable != null)
+                          _buildInfoRow(
+                            Icons.local_parking,
+                            '주차',
+                            shop.parkingAvailable! ? '가능' : '불가능',
+                          ),
+                        if (shop.fittingAvailable != null)
+                          _buildInfoRow(
+                            Icons.checkroom,
+                            '시착',
+                            shop.fittingAvailable! ? '가능' : '불가능',
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+                  
+                  // 온라인 쇼핑몰 정보
+                  if (shop.isOnline) ...[
+                    _buildSectionTitle(context, Icons.shopping_cart, '온라인몰 정보'),
+                    const SizedBox(height: 12),
+                    _buildInfoCard(
+                      context,
+                      children: [
+                        if (shop.websiteUrl != null)
+                          _buildInfoRow(Icons.language, '웹사이트', shop.websiteUrl!),
+                        if (shop.phone != null)
+                          _buildInfoRow(Icons.support_agent, '고객센터', shop.phone!),
+                        if (shop.shippingFee != null)
+                          _buildInfoRow(
+                            Icons.local_shipping,
+                            '배송비',
+                            shop.shippingFee == 0 
+                              ? '무료배송'
+                              : '${shop.shippingFee}원',
+                          ),
+                        if (shop.freeShippingMin != null && shop.freeShippingMin! > 0)
+                          _buildInfoRow(
+                            Icons.card_giftcard,
+                            '무료배송 조건',
+                            '${(shop.freeShippingMin! / 10000).toStringAsFixed(0)}만원 이상',
+                          ),
+                        if (shop.deliveryInfo != null)
+                          _buildInfoRow(Icons.schedule, '배송정보', shop.deliveryInfo!),
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+                  
+                  // 취급 브랜드
+                  _buildSectionTitle(context, Icons.style, '취급 브랜드'),
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: shop.brands.map((brand) => Chip(
+                      label: Text(brand),
+                      backgroundColor: AppColors.secondaryPurple,
+                      labelStyle: const TextStyle(
+                        color: AppColors.secondaryAccent,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )).toList(),
+                  ),
+                  const SizedBox(height: 24),
+                  
+                  // 취급 카테고리
+                  _buildSectionTitle(context, Icons.category, '주요 상품'),
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: shop.categories.map((category) => Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                      decoration: BoxDecoration(
+                        border: Border.all(color: AppColors.gray),
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Text(
+                        category,
+                        style: const TextStyle(
+                          fontSize: 13,
+                          color: AppColors.darkGray,
+                        ),
+                      ),
+                    )).toList(),
+                  ),
+                  const SizedBox(height: 40),
+                  
+                  // 액션 버튼들
+                  if (shop.isOffline)
+                    ElevatedButton.icon(
+                      onPressed: () {
+                        // TODO: 지도 앱 연동
+                      },
+                      icon: const Icon(Icons.directions),
+                      label: const Text('길찾기'),
+                      style: ElevatedButton.styleFrom(
+                        minimumSize: const Size.fromHeight(48),
+                      ),
+                    ),
+                  if (shop.isOnline)
+                    ElevatedButton.icon(
+                      onPressed: () {
+                        // TODO: 웹사이트 열기
+                      },
+                      icon: const Icon(Icons.open_in_new),
+                      label: const Text('웹사이트 방문'),
+                      style: ElevatedButton.styleFrom(
+                        minimumSize: const Size.fromHeight(48),
+                      ),
+                    ),
+                  if (shop.phone != null) ...[
+                    const SizedBox(height: 12),
+                    OutlinedButton.icon(
+                      onPressed: () {
+                        // TODO: 전화 걸기
+                      },
+                      icon: const Icon(Icons.call),
+                      label: Text('전화 문의 (${shop.phone})'),
+                      style: OutlinedButton.styleFrom(
+                        minimumSize: const Size.fromHeight(48),
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 40),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+  
+  Widget _buildSectionTitle(BuildContext context, IconData icon, String title) {
+    return Row(
+      children: [
+        Icon(icon, size: 20, color: AppColors.primaryAccent),
+        const SizedBox(width: 8),
+        Text(
+          title,
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+      ],
+    );
+  }
+  
+  Widget _buildInfoCard(BuildContext context, {required List<Widget> children}) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.lightGray,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: children,
+      ),
+    );
+  }
+  
+  Widget _buildInfoRow(IconData icon, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 18, color: AppColors.gray),
+          const SizedBox(width: 12),
+          SizedBox(
+            width: 80,
+            child: Text(
+              label,
+              style: const TextStyle(
+                color: AppColors.gray,
+                fontSize: 14,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(
+                color: AppColors.black,
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+  
+  Color _getShopTypeColor(ShopType type) {
+    switch (type) {
+      case ShopType.offline:
+        return AppColors.offlineShop;
+      case ShopType.online:
+        return AppColors.onlineShop;
+      case ShopType.hybrid:
+        return AppColors.secondaryAccent;
+    }
+  }
+  
+  IconData _getShopTypeIcon(ShopType type) {
+    switch (type) {
+      case ShopType.offline:
+        return Icons.store;
+      case ShopType.online:
+        return Icons.shopping_cart;
+      case ShopType.hybrid:
+        return Icons.storefront;
+    }
+  }
+}

--- a/lib/widgets/shop_card.dart
+++ b/lib/widgets/shop_card.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import '../models/shop.dart';
+import '../theme/app_colors.dart';
+
+class ShopCard extends StatelessWidget {
+  final Shop shop;
+  final VoidCallback onTap;
+  
+  const ShopCard({
+    super.key,
+    required this.shop,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        decoration: BoxDecoration(
+          color: AppColors.white,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withAlpha(13),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 이미지 섹션
+            Stack(
+              children: [
+                ClipRRect(
+                  borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+                  child: Image.network(
+                    shop.imageUrl,
+                    height: 160,
+                    width: double.infinity,
+                    fit: BoxFit.cover,
+                    errorBuilder: (context, error, stackTrace) {
+                      return Container(
+                        height: 160,
+                        color: AppColors.lightGray,
+                        child: const Center(
+                          child: Icon(
+                            Icons.store,
+                            size: 60,
+                            color: AppColors.gray,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+                // 상점 유형 배지
+                Positioned(
+                  top: 12,
+                  left: 12,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: _getShopTypeColor(shop.shopType),
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          _getShopTypeIcon(shop.shopType),
+                          size: 14,
+                          color: AppColors.white,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          shop.shopType.displayName,
+                          style: const TextStyle(
+                            color: AppColors.white,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                // 인증 배지
+                if (shop.isVerified)
+                  Positioned(
+                    top: 12,
+                    right: 12,
+                    child: Container(
+                      padding: const EdgeInsets.all(6),
+                      decoration: const BoxDecoration(
+                        color: AppColors.success,
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.verified,
+                        size: 16,
+                        color: AppColors.white,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            
+            // 정보 섹션
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 상점명
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          shop.name,
+                          style: Theme.of(context).textTheme.titleLarge,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      // 평점
+                      Row(
+                        children: [
+                          const Icon(
+                            Icons.star,
+                            size: 16,
+                            color: AppColors.warning,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            shop.ratingText,
+                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          Text(
+                            ' (${shop.reviewCount})',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  
+                  // 설명
+                  Text(
+                    shop.description,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 12),
+                  
+                  // 위치 또는 배송 정보
+                  Row(
+                    children: [
+                      Icon(
+                        shop.isOffline ? Icons.location_on : Icons.local_shipping,
+                        size: 16,
+                        color: AppColors.gray,
+                      ),
+                      const SizedBox(width: 4),
+                      Expanded(
+                        child: Text(
+                          shop.isOffline 
+                            ? (shop.address ?? '위치 정보 없음')
+                            : shop.hasFreeShipping
+                              ? '${(shop.freeShippingMin! / 10000).toStringAsFixed(0)}만원 이상 무료배송'
+                              : '배송비 ${shop.shippingFee ?? 0}원',
+                          style: Theme.of(context).textTheme.bodySmall,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  
+                  // 브랜드 태그들
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: shop.mainBrands.map((brand) => Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: AppColors.secondaryPurple,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        brand,
+                        style: const TextStyle(
+                          fontSize: 11,
+                          color: AppColors.secondaryAccent,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    )).toList(),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+  
+  Color _getShopTypeColor(ShopType type) {
+    switch (type) {
+      case ShopType.offline:
+        return AppColors.offlineShop;
+      case ShopType.online:
+        return AppColors.onlineShop;
+      case ShopType.hybrid:
+        return AppColors.secondaryAccent;
+    }
+  }
+  
+  IconData _getShopTypeIcon(ShopType type) {
+    switch (type) {
+      case ShopType.offline:
+        return Icons.store;
+      case ShopType.online:
+        return Icons.shopping_cart;
+      case ShopType.hybrid:
+        return Icons.storefront;
+    }
+  }
+}


### PR DESCRIPTION
- Shop 모델 클래스 정의 (온라인/오프라인/하이브리드 타입)
- 12개 더미 상점 데이터 생성
- ShopCard 위젯 구현 (이미지, 평점, 브랜드, 배송정보)
- 홈 화면에 상점 리스트 표시
- 상점 유형별 필터링 기능 구현
- 상점 상세 화면 구현 (유형별 맞춤 정보)
- 온/오프라인 상점 시각적 구분 (색상, 아이콘)

Phase 2 MVP 완료: 정적 데이터로 상점 목록과 상세정보 표시