### PR TITLE
perf: Day 2 - Lazy Loading 탭 구현으로 메모리 사용량 최적화

### DIFF
--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'home_screen.dart';
 import 'search_screen.dart';
 import 'map_screen.dart';
@@ -13,13 +14,37 @@ class MainScreen extends StatefulWidget {
 
 class _MainScreenState extends State<MainScreen> {
   int _currentIndex = 0;
+  late PageController _pageController;
   
+  // 각 탭의 화면을 캐싱하기 위한 Map
+  final Map<int, Widget> _cachedScreens = {};
+  
+  // 각 탭의 Navigator Key를 유지
   final List<GlobalKey<NavigatorState>> _navigatorKeys = [
     GlobalKey<NavigatorState>(),
     GlobalKey<NavigatorState>(),
     GlobalKey<NavigatorState>(),
     GlobalKey<NavigatorState>(),
   ];
+  
+  // 각 탭의 로드 상태를 추적
+  final Set<int> _loadedTabs = {0}; // 홈 화면은 기본적으로 로드
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController(initialPage: _currentIndex);
+    
+    if (kDebugMode) {
+      print('🚀 MainScreen initialized with Lazy Loading');
+    }
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,9 +56,11 @@ class _MainScreenState extends State<MainScreen> {
             !await _navigatorKeys[_currentIndex].currentState!.maybePop();
         if (isFirstRouteInCurrentTab) {
           if (_currentIndex != 0) {
-            setState(() {
-              _currentIndex = 0;
-            });
+            _pageController.animateToPage(
+              0,
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+            );
           } else {
             // 앱 종료 처리
             if (context.mounted) {
@@ -43,62 +70,113 @@ class _MainScreenState extends State<MainScreen> {
         }
       },
       child: Scaffold(
-        body: IndexedStack(
-          index: _currentIndex,
-          children: [
-            _buildNavigator(0, const HomeScreen()),
-            _buildNavigator(1, const SearchScreen()),
-            _buildNavigator(2, const MapScreen()),
-            _buildNavigator(3, const ProfileScreen()),
-          ],
-        ),
-      bottomNavigationBar: Container(
-        decoration: BoxDecoration(
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withAlpha(26),
-              blurRadius: 10,
-              offset: const Offset(0, -5),
-            ),
-          ],
-        ),
-        child: BottomNavigationBar(
-          currentIndex: _currentIndex,
-          onTap: (index) {
-            setState(() {
-              _currentIndex = index;
-            });
+        body: PageView.builder(
+          controller: _pageController,
+          physics: const NeverScrollableScrollPhysics(), // 스와이프 비활성화
+          itemCount: 4,
+          itemBuilder: (context, index) {
+            // 한 번 로드된 화면은 캐싱하여 재사용
+            if (_cachedScreens.containsKey(index)) {
+              if (kDebugMode) {
+                print('📱 Tab $index: Using cached screen');
+              }
+              return _cachedScreens[index]!;
+            }
+            
+            // 처음 로드하는 화면
+            if (kDebugMode) {
+              print('🔄 Tab $index: Loading new screen');
+            }
+            
+            Widget screen = _buildLazyScreen(index);
+            _cachedScreens[index] = screen;
+            _loadedTabs.add(index);
+            
+            return screen;
           },
-          type: BottomNavigationBarType.fixed,
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.home_outlined),
-              activeIcon: Icon(Icons.home),
-              label: '홈',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.search_outlined),
-              activeIcon: Icon(Icons.search),
-              label: '검색',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.map_outlined),
-              activeIcon: Icon(Icons.map),
-              label: '지도',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.person_outline),
-              activeIcon: Icon(Icons.person),
-              label: '마이페이지',
-            ),
-          ],
         ),
+        bottomNavigationBar: Container(
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withAlpha(26),
+                blurRadius: 10,
+                offset: const Offset(0, -5),
+              ),
+            ],
+          ),
+          child: BottomNavigationBar(
+            currentIndex: _currentIndex,
+            onTap: (index) {
+              if (kDebugMode) {
+                print('🔸 Tab switched to: $index');
+                print('🔸 Tab $index loaded: ${_loadedTabs.contains(index)}');
+              }
+              
+              setState(() {
+                _currentIndex = index;
+              });
+              
+              // PageView를 해당 페이지로 이동
+              _pageController.jumpToPage(index);
+              
+              // 메모리 사용량 로깅 (디버그 모드)
+              if (kDebugMode) {
+                print('📊 Loaded tabs: $_loadedTabs');
+                print('📊 Cached screens: ${_cachedScreens.keys}');
+              }
+            },
+            type: BottomNavigationBarType.fixed,
+            items: const [
+              BottomNavigationBarItem(
+                icon: Icon(Icons.home_outlined),
+                activeIcon: Icon(Icons.home),
+                label: '홈',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.search_outlined),
+                activeIcon: Icon(Icons.search),
+                label: '검색',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.map_outlined),
+                activeIcon: Icon(Icons.map),
+                label: '지도',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.person_outline),
+                activeIcon: Icon(Icons.person),
+                label: '마이페이지',
+              ),
+            ],
+          ),
         ),
       ),
     );
   }
   
-  Widget _buildNavigator(int index, Widget screen) {
+  // Lazy Loading을 위한 화면 빌더
+  Widget _buildLazyScreen(int index) {
+    Widget screen;
+    
+    switch (index) {
+      case 0:
+        screen = const HomeScreen();
+        break;
+      case 1:
+        screen = const SearchScreen();
+        break;
+      case 2:
+        screen = const MapScreen();
+        break;
+      case 3:
+        screen = const ProfileScreen();
+        break;
+      default:
+        screen = const HomeScreen();
+    }
+    
+    // Navigator로 감싸서 각 탭에서 독립적인 네비게이션 스택 유지
     return Navigator(
       key: _navigatorKeys[index],
       onGenerateRoute: (routeSettings) {


### PR DESCRIPTION
## Summary
- IndexedStack을 PageView로 변경하여 탭 화면 Lazy Loading 구현
- 화면 캐싱 메커니즘 추가로 재방문 시 빠른 로딩
- 초기 로딩 시 메모리 사용량 감소

## Changes
- `MainScreen`을 IndexedStack에서 PageView 기반으로 변경
- 탭 화면들이 필요할 때만 로드되도록 구현
- 한 번 로드된 화면은 캐싱하여 재사용

## Test Plan
✅ 앱 실행 시 첫 번째 탭(홈)만 로드되는지 확인
✅ 다른 탭 클릭 시 해당 화면이 처음 로드되는지 확인
✅ 이미 방문한 탭으로 돌아갈 때 빠르게 표시되는지 확인
✅ 메모리 사용량이 개선되었는지 확인

## Performance Impact
- 초기 앱 로딩 시 4개 화면 대신 1개만 로드
- 메모리 사용량 약 30-40% 감소 예상
- 탭 전환 시 첫 로드는 약간 지연될 수 있으나, 캐싱으로 이후 빠른 전환

🤖 Generated with [Claude Code](https://claude.ai/code)